### PR TITLE
Update Hash Rounds + DisplayName case

### DIFF
--- a/main.py
+++ b/main.py
@@ -143,7 +143,7 @@ def main(argv):
 
         for line in lines:
             if displayname is None:
-                match = re.match('displayname *= *"(.+)"\n', line)
+                match = re.match('displayname *= *"(.+)"\n', line, re.IGNORECASE)
                 if match:
                     displayname = match.group(1)
             if 'encryption.keySafe' in line:

--- a/vmwarevmx.py
+++ b/vmwarevmx.py
@@ -68,7 +68,7 @@ class VMwareVMX(object):
     __AES_MODE = AES.MODE_CBC
     __HASH_SIZE = 20  # sha1
     __DICT_SIZE = AES_IV_SIZE + 80 + __HASH_SIZE
-    __HASH_ROUNDS = 1000
+    __HASH_ROUNDS = 10000
 
     def __init__(self):
         """Initialize the public attributes


### PR DESCRIPTION
vmware fusion 11.x seem to use 10000 rounds by default.