### PR TITLE
fix: Do not add "None" to output file if guestOSdetaileddata is empty

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ def main(argv):
     config = None
     decrypt = False
     displayname = None
-    guestOSdetaileddata = None
+    guestOSdetaileddata = ""
 
     encrypt = False
     force = False
@@ -215,7 +215,7 @@ def main(argv):
         if displayname is None:
             sys.exit('Error: Displayname is missing')
 
-        if guestOSdetaileddata is not None:
+        if guestOSdetaileddata:
           guestOSdetaileddata = 'guestOS.detailed.data = "{g}"\n' \
                                 .format(g=guestOSdetaileddata)
         if config is None:


### PR DESCRIPTION
Fixes #10 in original repo

I never saw guestOS.detailed.data in my encrypted VMX files.
As far as I understand it, a parameter should be added to set guestOSdetaileddata for file encryption (similar to -D)