### PR TITLE
Fixing Unicode Error on File Encrption by Declaring to Use "UTF-8"

### DIFF
--- a/main.py
+++ b/main.py
@@ -200,7 +200,7 @@ def main(argv):
     # Add lines to the configuration
     if add:
         try:
-            addconfig = open(addfilename, "r").read()
+            addconfig = open(addfilename, "r", encoding="utf8").read()
         except (OSError, IOError):
             sys.exit('Error: Cannot read from file ' + addfilename)
 


### PR DESCRIPTION
Found an error while using this command:
python main.py -a add.txt "Lab Windows 11.vmx" > "Lab Windows 11 Revised.vmx"

And got:
Traceback (most recent call last):
  File "C:\Users\ACER\Downloads\Compressed\VMwareVMX-master\VMwareVMX-master\main.py", line 247, in <module>
    main(sys.argv)
  File "C:\Users\ACER\Downloads\Compressed\VMwareVMX-master\VMwareVMX-master\main.py", line 203, in main
    addconfig = open(addfilename, "r").read()
  File "C:\Users\ACER\AppData\Local\Programs\Python\Python39\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 30: character maps to <undefined>


Solved by adding encoding="utf8" in line 203.
No side effects observed.